### PR TITLE
Io warnings fix

### DIFF
--- a/chapel/Bude.chpl
+++ b/chapel/Bude.chpl
@@ -46,14 +46,14 @@ module Bude {
 
   class params {
     var deckDir: string;
-    var iterations: int(32);
-    var natlig, natpro, ntypes, nposes: int(32);
+    var iterations: int;
+    var natlig, natpro, ntypes, nposes: int;
     var wgsize: int;
 
-    var proteinDomain: domain(1,int(32));
-    var ligandDomain: domain(1,int(32));
-    var forcefieldDomain: domain(1,int(32));
-    var posesDomain: domain(2,int(32));
+    var proteinDomain: domain(1);
+    var ligandDomain: domain(1);
+    var forcefieldDomain: domain(1);
+    var posesDomain: domain(2);
 
     var protein: [proteinDomain] atom; 
     var ligand: [ligandDomain] atom;
@@ -117,38 +117,38 @@ module Bude {
       // Load data
       var length: int;
       var aFile: file;
-      var reader: fileReader();
+      var reader: fileReader(locking=false, ?);
       
       // Read ligand
       aFile = openFile(this.deckDir + FILE_LIGAND, length);
-      this.natlig = (length / c_sizeof(atom)): int(32);
+      this.natlig = length / c_sizeof(atom): int;
       this.ligandDomain = {0..<this.natlig};
-      reader = aFile.reader(kind=iokind.native, region=0..);
+      reader = aFile.reader(region=0.., deserializer=new binaryDeserializer());
       reader.read(this.ligand);
       reader.close(); aFile.close();
 
       // Read protein
       aFile = openFile(this.deckDir + FILE_PROTEIN, length);
-      this.natpro = (length / c_sizeof(atom)): int(32);
+      this.natpro = length / c_sizeof(atom): int;
       this.proteinDomain = {0..<this.natpro};
-      reader = aFile.reader(kind=iokind.native, region=0..);
+      reader = aFile.reader(region=0.., deserializer=new binaryDeserializer());
       reader.read(this.protein);
       reader.close(); aFile.close();
 
       // Read force field
       aFile = openFile(this.deckDir + FILE_FORCEFIELD, length);
-      this.ntypes = (length / c_sizeof(ffParams)): int(32);
+      this.ntypes = length / c_sizeof(ffParams): int;
       this.forcefieldDomain = {0..<this.ntypes};
-      reader = aFile.reader(kind=iokind.native, region=0..);
+      reader = aFile.reader(region=0.., deserializer=new binaryDeserializer());
       reader.read(this.forcefield);
       reader.close(); aFile.close();
 
       // Read poses
-      this.posesDomain = {0..<6:int(32), 0..<this.nposes};
+      this.posesDomain = {0..<6, 0..<this.nposes};
       aFile = openFile(this.deckDir + FILE_POSES, length);
-      const reader_tmp =  aFile.reader(kind=iokind.native, region=0.., locking=false);
-      var available = (length / (6 * c_sizeof(real(32)): int)): int(32);
-      var current = 0:int(32);
+      reader = aFile.reader(region=0.., deserializer=new binaryDeserializer());
+      var available = (length / (6 * c_sizeof(real(32)): int));
+      var current = 0;
       while (current < this.nposes) {
         var fetch = this.nposes - current;
         if (fetch > available) then fetch = available;
@@ -156,8 +156,8 @@ module Bude {
         for i in posesDomain.dim(0) {
           const base = i*available*c_sizeof(real(32)):int;
           const amount = fetch*c_sizeof(real(32)):int;
-          reader_tmp.seek(region=base..base+amount);
-          reader_tmp.read(this.poses(i, current..));
+          reader.seek(region=base..base+amount);
+          reader.read(this.poses(i, current..));
         }
         current += fetch;
       }

--- a/chapel/Bude.chpl
+++ b/chapel/Bude.chpl
@@ -30,7 +30,7 @@ module Bude {
   const NPPDIST: real(32) = 1.0;
 
   // Configurations
-  config param NUM_TD_PER_THREAD: int(32) = 4; // Work per core
+  config param NUM_TD_PER_THREAD: int = 4; // Work per core
 
   record atom {
     var x, y, z: real(32);

--- a/chapel/GKernel.chpl
+++ b/chapel/GKernel.chpl
@@ -5,7 +5,7 @@ module GKernel {
   proc gkernel(context: params, results: [] real(32)) {
     const ngpu = here.gpus.size;
     var times: [0..<ngpu] real;
-    coforall (gpu, gpuID) in zip(here.gpus, here.gpus.domain) do on gpu {
+    coforall (gpu, gpuID) in zip(here.gpus, here.gpus.domain) with (ref times) do on gpu {
       const iterations = context.iterations: int(32);
       const nposes = (context.nposes / ngpu) : int(32);
       const natlig = context.natlig: int(32);
@@ -15,7 +15,7 @@ module GKernel {
       const protein = context.protein;
       const ligand = context.ligand;
       const forcefield = context.forcefield;
-      const poses: [0..<6:int(32), 0..<nposes] real(32) = context.poses[.., gpuID*nposes..<(gpuID+1)*nposes];
+      const poses: [{0:int(32)..<6:int(32), 0..<nposes}] real(32) = context.poses[{0..<6, gpuID*nposes..<(gpuID+1)*nposes}];
       var buffer: [0..<nposes] real(32);
 
       times[gpuID] = timestampMS();


### PR DESCRIPTION
## Fix IO warnings
- Fix warnings according to [Engin's pull request](https://github.com/chapel-lang/chapel/pull/24073/commits/a8767e37fe19670932979e67dc9fc82cd79f761f ).
- Change `int(32)` to `int` in parts that do not contribute to the computation.
- Use new IO.